### PR TITLE
Added an AnalyticsHelper to allow for a more succinct way to specify traits and properties

### DIFF
--- a/Analytics/Analytics.csproj
+++ b/Analytics/Analytics.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Analytics</RootNamespace>
     <AssemblyName>Analytics.NET</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProductVersion>10.0.0</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -32,6 +33,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
@@ -41,11 +46,9 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.5.0.6\lib\net35\Newtonsoft.Json.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AnalyticsHelper.cs" />
     <Compile Include="Client.cs" />
     <Compile Include="Defaults.cs" />
     <Compile Include="Exception\BadParameter.cs" />
@@ -90,7 +93,5 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <ItemGroup>
-    <Folder Include="Flush\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>

--- a/Analytics/AnalyticsHelper.cs
+++ b/Analytics/AnalyticsHelper.cs
@@ -1,0 +1,75 @@
+﻿using Segmentio;
+using Segmentio.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace Segmentio
+{
+    public static class AnalyticsHelper
+    {
+        public static void Initialize(string writeKey, Options options = null)
+        {
+            // Make sure the options are initialized
+            options = options ?? new Options();
+#if DEBUG
+            // Run synchronously when debugging
+            options = options.SetAsync(false);
+#endif
+
+            Analytics.Initialize(writeKey, options);
+        }
+
+        public static void Identify(string userId, dynamic traits)
+        {
+            Analytics.Client.Identify(userId, SegmentIoTraits(traits));
+        }
+
+        public static void Track(string userId, string eventName)
+        {
+            Track(userId, eventName, null, null, null);
+        }
+
+        public static void Track(string userId, string eventName, dynamic properties)
+        {
+            Track(userId, eventName, properties, null, null);
+        }
+
+        public static void Track(string userId, string eventName, dynamic properties, DateTime? timestamp)
+        {
+            Track(userId, eventName, properties, timestamp, null);
+        }
+
+        public static void Track(string userId, string eventName, dynamic properties, DateTime? timestamp, Context context)
+        {
+            Analytics.Client.Track(userId, eventName, SegmentIoProperties(properties), timestamp, context);
+        }
+
+        private static Segmentio.Model.Properties SegmentIoProperties(dynamic obj)
+        {
+            return PropDictionary<Segmentio.Model.Properties>(obj);
+        }
+
+        private static Segmentio.Model.Traits SegmentIoTraits(dynamic obj)
+        {
+            return PropDictionary<Segmentio.Model.Traits>(obj);
+        }
+
+        private static T PropDictionary<T>(dynamic obj)
+            where T : Dictionary<string, object>, new()
+        {
+            // Null stays null
+            if (obj == null)
+                return null;
+
+            // Everything else we convert to a dictionary
+            var dictionary = new T();
+            foreach (var propertyInfo in obj.GetType().GetProperties())
+                if (propertyInfo.CanRead && propertyInfo.GetIndexParameters().Length == 0)
+                    dictionary[propertyInfo.Name] = propertyInfo.GetValue(obj, null);
+            return dictionary;
+        }
+    }
+}

--- a/Analytics/Client.cs
+++ b/Analytics/Client.cs
@@ -110,7 +110,6 @@ namespace Segmentio
             Identify(userId, traits, null, null);
         }
 
-
         /// <summary>
         /// Identifying a visitor ties all of their actions to an ID you
         /// recognize and records visitor traits you can segment by.

--- a/Analytics/packages.config
+++ b/Analytics/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net35" />
-  <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net35" />
+  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net40" />
 </packages>

--- a/Test/ContextSerializerTests.cs
+++ b/Test/ContextSerializerTests.cs
@@ -83,6 +83,81 @@ namespace Analytics.Test
 			string json = JsonConvert.SerializeObject(identify, settings);
 			Assert.IsTrue(json.Contains("\"providers\""));
 		}
+
+
+
+        [TestMethod]
+        public void SerializationOfTrackIncludesContextWithIPAddress()
+        {
+            var track = new Track(
+                "99",
+                "Ran .NET test",
+                new Properties() {
+                        { "Success", true },
+                        { "When", DateTime.Now }
+                    },
+                DateTime.Now,
+                        new Context()
+                            .SetIp("12.212.12.49")
+                );
+
+            var settings = new JsonSerializerSettings
+            {
+                Converters = new List<JsonConverter> { new ContextSerializer() }
+            };
+            string json = JsonConvert.SerializeObject(track, settings);
+            Assert.IsTrue(json.Contains("\"ip\":\"12.212.12.49\""));
+        }
+
+        [TestMethod]
+        public void SerializationOfTrackIncludesContextWithLanguage()
+        {
+            var track = new Track(
+                "99",
+                "Ran .NET test",
+                new Properties() {
+                        { "Success", true },
+                        { "When", DateTime.Now }
+                    },
+                DateTime.Now,
+                        new Context()
+                            .SetLanguage("fr")
+                );
+
+            var settings = new JsonSerializerSettings
+            {
+                Converters = new List<JsonConverter> { new ContextSerializer() }
+            };
+            string json = JsonConvert.SerializeObject(track, settings);
+            Assert.IsTrue(json.Contains("\"language\":\"fr\""));
+        }
+
+        [TestMethod]
+        public void SerializationOfTrackIncludesContextWithProviders()
+        {
+            var track = new Track(
+                "99", 
+                "Ran .NET test", 
+                new Properties() {
+                        { "Success", true },
+                        { "When", DateTime.Now }
+                    }, 
+                DateTime.Now,
+                        new Context()
+                            .SetProviders(new Providers() {
+                                    { "all", false },
+                                    { "Mixpanel", true },
+                                    { "Salesforce", true }
+                                })
+                );
+
+            var settings = new JsonSerializerSettings
+            {
+                Converters = new List<JsonConverter> { new ContextSerializer() }
+            };
+            string json = JsonConvert.SerializeObject(track, settings);
+            Assert.IsTrue(json.Contains("\"providers\""));
+        }
 	}
 
 	

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Analytics.Test</RootNamespace>
     <AssemblyName>Analytics.Test</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TestProjectType>UnitTest</TestProjectType>
@@ -35,9 +35,8 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net35\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/Test/packages.config
+++ b/Test/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net35" />
+  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
An example of how to use the analytics helper:

``` csharp
AnalyticsHelper.Identify("fake_user_id", new { 
                    email = "joe@acme.inc", 
                    first_name = "Joe", 
                    last_name = "Shmoe",
                    project_count = 3
                });
```
