### PR TITLE
Identify supports no userId. HasAnonymousId follows its naming semantics

### DIFF
--- a/Analytics/Client.cs
+++ b/Analytics/Client.cs
@@ -129,7 +129,7 @@ namespace Segment
         ///
 		public void Identify(string userId, Traits traits, Options options)
         {
-			if (String.IsNullOrEmpty(userId))
+			if (String.IsNullOrEmpty(userId) && !HasAnonymousId(options))
 				throw new InvalidOperationException("Please supply a valid userId to Identify.");
 
 			Enqueue(new Identify(userId, traits, options));
@@ -204,7 +204,7 @@ namespace Segment
 		///
 		public void Group(string userId, string groupId, Traits traits, Options options)
 		{
-			if (String.IsNullOrEmpty(userId) && HasAnonymousId(options))
+			if (String.IsNullOrEmpty(userId) && !HasAnonymousId(options))
 				throw new InvalidOperationException("Please supply a valid userId or anonymousID to call #Group.");
 
 			if (String.IsNullOrEmpty(groupId))
@@ -300,7 +300,7 @@ namespace Segment
 		///
 		public void Track(string userId, string eventName, Properties properties, Options options)
 		{
-			if (String.IsNullOrEmpty(userId) && HasAnonymousId(options))
+			if (String.IsNullOrEmpty(userId) && !HasAnonymousId(options))
 				throw new InvalidOperationException("Please supply a valid userId or anonymousId to Track.");
 
 			if (String.IsNullOrEmpty(eventName))
@@ -470,7 +470,7 @@ namespace Segment
 		///
 		public void Page(string userId, string name, string category, Properties properties, Options options)
 		{
-			if (String.IsNullOrEmpty(userId) && HasAnonymousId(options))
+			if (String.IsNullOrEmpty(userId) && !HasAnonymousId(options))
 				throw new InvalidOperationException("Please supply a valid userId or anonymousId to #Page.");
 
 			if (String.IsNullOrEmpty(name))
@@ -607,7 +607,7 @@ namespace Segment
 		///
 		public void Screen(string userId, string name, string category, Properties properties, Options options)
 		{
-			if (String.IsNullOrEmpty(userId) && HasAnonymousId(options))
+			if (String.IsNullOrEmpty(userId) && !HasAnonymousId(options))
 				throw new InvalidOperationException("Please supply a valid userId or anonymousId to #Screen.");
 
 			if (String.IsNullOrEmpty(name))
@@ -668,13 +668,13 @@ namespace Segment
         }
 
 		/// <summary>
-		/// Determines whether this instance has define a anonymous identifier in the specified options.
+		/// Determines whether an anonymous identifier is defined in the specified options.
 		/// </summary>
-		/// <returns><c>true</c> if this instance has anonymous identifier the specified options; otherwise, <c>false</c>.</returns>
+		/// <returns><c>true</c> if the specified options have an anonymous identifier; otherwise, <c>false</c>.</returns>
 		/// <param name="options">Options.</param>
-		internal bool HasAnonymousId(Options options)
+		internal static bool HasAnonymousId(Options options)
 		{
-			return options == null || String.IsNullOrEmpty(options.AnonymousId);
+			return options != null &&  !String.IsNullOrEmpty(options.AnonymousId);
 		}
 
         #endregion


### PR DESCRIPTION
This is primarily to support a null/empty userId on Identify calls. For issue #25 

Also, while looking at the code I was confused by the `internal bool HasAnonymousId` since it was returning the opposite of what was expected based on its name. Re-factored the method and updated everywhere it was used.