### PR TITLE
Update project to use the fully qualified name for JSON.NET

### DIFF
--- a/Analytics/Analytics.csproj
+++ b/Analytics/Analytics.csproj
@@ -29,6 +29,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net35\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
@@ -38,9 +42,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net35\Newtonsoft.Json.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Client.cs" />
@@ -80,8 +81,8 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="History.md" />
-    <None Include="packages.config" />
     <None Include="Analytics.nuspec" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
This is a potential fix for #28. I believe it's because a fully qualified assembly name isn't included in the Segment reference, so it will introduce issues if you add Segment to a project that also uses JSON.NET with a different version.

The code change is a result of running:
`update-package -reinstall Newtonsoft.Json`
