### PR TITLE
Update XML comments in documentation

### DIFF
--- a/Analytics/Client.cs
+++ b/Analytics/Client.cs
@@ -200,7 +200,7 @@ namespace Segment
 		/// String key, then its value { String, Integer, Boolean, Double, or Date are acceptable types for a value. } </param>
 		///
 		/// <param name="options">Options allowing you to set timestamp, anonymousId, target integrations,
-		/// and the context of th emessage.</param>
+		/// and the context of the message.</param>
 		///
 		public void Group(string userId, string groupId, Traits traits, Options options)
 		{

--- a/Analytics/Model/Options.cs
+++ b/Analytics/Model/Options.cs
@@ -34,9 +34,9 @@ namespace Segment.Model
 		}
 			
 		/// <summary>
-		/// Sets the timestamp of when an analytics call occured. The timestamp is primarily used for 
+		/// Sets the timestamp of when an analytics call occurred. The timestamp is primarily used for 
 		/// historical imports or if this event happened in the past. The timestamp is not required, 
-		/// and if its not provided, our servers will timestamp the call as if it just happened.
+		/// and if it's not provided, our servers will timestamp the call as if it just happened.
 		/// </summary>
 		/// <returns>This Options object for chaining.</returns>
 		/// <param name="timestamp">The call's timestamp.</param>
@@ -47,7 +47,7 @@ namespace Segment.Model
 		}
 
 		/// <summary>
-		/// Sets the context of this analytics call. Context contains information about the environemtn
+		/// Sets the context of this analytics call. Context contains information about the environment
 		/// such as the app, the user agent, ip, etc ..
 		/// </summary>
 		/// <returns>This Options object for chaining.</returns>

--- a/Analytics/Model/Options.cs
+++ b/Analytics/Model/Options.cs
@@ -39,7 +39,7 @@ namespace Segment.Model
 		/// and if its not provided, our servers will timestamp the call as if it just happened.
 		/// </summary>
 		/// <returns>This Options object for chaining.</returns>
-		/// <param name="anonymousId">The call's timestamp.</param>
+		/// <param name="timestamp">The call's timestamp.</param>
 		public Options SetTimestamp (DateTime? timestamp)
 		{
 			this.Timestamp = timestamp;
@@ -51,7 +51,7 @@ namespace Segment.Model
 		/// such as the app, the user agent, ip, etc ..
 		/// </summary>
 		/// <returns>This Options object for chaining.</returns>
-		/// <param name="anonymousId">The visitor's context.</param>
+		/// <param name="context">The visitor's context.</param>
 		public Options SetContext (Context context)
 		{
 			this.Context = context;


### PR DESCRIPTION
This is just a quality of life change to fix some errors in the XML comments. Typos, mismatched parameter names in `param` fields, etc.
