### PR TITLE
Add .Net 4.5 version of Analytics library for Xamarin compatible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,3 +62,4 @@ workflows:
       - build
       - test
       - test_35
+      - test_45

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,8 @@ jobs:
       - run: msbuild Analytics.NetStandard20/Analytics.NetStandard20.csproj /p:Configuration=Release
       - run: msbuild Analytics.Net35/Analytics.Net35.csproj /t:restore
       - run: msbuild Analytics.Net35/Analytics.Net35.csproj /p:Configuration=Release
+      - run: msbuild Analytics.Net45/Analytics.Net45.csproj /t:restore
+      - run: msbuild Analytics.Net45/Analytics.Net45.csproj /p:Configuration=Release
       - run: nuget pack Analytics.nuspec
   test:
     working_directory: /test
@@ -40,6 +42,19 @@ jobs:
       - run: msbuild Test.Net35/Test.Net35.csproj /t:restore
       - run: msbuild Test.Net35/Test.Net35.csproj /p:Configuration=Release
       - run: mono --debug ./packages/NUnit.ConsoleRunner.3.7.0/tools/nunit3-console.exe Test.Net35/bin/Release/Test.Net35.dll
+  test_45:
+    working_directory: /test45
+    docker:  
+      - image: mono:latest
+    environment:
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+      DOTNET_CLI_TELEMETRY_OUTPUT: 1
+    steps:
+      - checkout
+      - run: nuget restore
+      - run: msbuild Test.Net45/Test.Net45.csproj /t:restore
+      - run: msbuild Test.Net45/Test.Net45.csproj /p:Configuration=Release
+      - run: mono --debug ./packages/NUnit.ConsoleRunner.3.7.0/tools/nunit3-console.exe Test.Net45/bin/Release/Test.Net45.dll
 workflows:
   version: 2
   build_and_test:

--- a/Analytics.NET.sln
+++ b/Analytics.NET.sln
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.NetStandard20", "Test.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Analytics.Net45", "Analytics.Net45\Analytics.Net45.csproj", "{3EBD38D6-E04D-4E23-88C1-2BC32689EE8B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test.Net45", "Test.Net45\Test.Net45.csproj", "{A7B43E75-BA62-4543-A467-27C6D9B28EB8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,10 @@ Global
 		{3EBD38D6-E04D-4E23-88C1-2BC32689EE8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3EBD38D6-E04D-4E23-88C1-2BC32689EE8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3EBD38D6-E04D-4E23-88C1-2BC32689EE8B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A7B43E75-BA62-4543-A467-27C6D9B28EB8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7B43E75-BA62-4543-A467-27C6D9B28EB8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7B43E75-BA62-4543-A467-27C6D9B28EB8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7B43E75-BA62-4543-A467-27C6D9B28EB8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Analytics.NET.sln
+++ b/Analytics.NET.sln
@@ -1,11 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.16
+VisualStudioVersion = 15.0.27004.2008
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Analytics", "Analytics/Analytics.csproj", "{A386CF02-D902-4B22-90A8-E828093E3AA4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Analytics", "Analytics\Analytics.csproj", "{A386CF02-D902-4B22-90A8-E828093E3AA4}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test", "Test/Test.csproj", "{6AE99FF7-EECF-4639-B6B1-3E7CF1CC3048}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test", "Test\Test.csproj", "{6AE99FF7-EECF-4639-B6B1-3E7CF1CC3048}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C316F1BB-6C70-4DEB-BC04-5664C39313F3}"
 	ProjectSection(SolutionItems) = preProject
@@ -13,13 +13,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test.Net35", "Test.Net35/Test.Net35.csproj", "{14046A5D-168B-4320-B031-C72BEE19F206}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test.Net35", "Test.Net35\Test.Net35.csproj", "{14046A5D-168B-4320-B031-C72BEE19F206}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Analytics.Net35", "Analytics.Net35/Analytics.Net35.csproj", "{6A4B32F2-0A3D-4031-A2DF-EED9BD99501D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Analytics.Net35", "Analytics.Net35\Analytics.Net35.csproj", "{6A4B32F2-0A3D-4031-A2DF-EED9BD99501D}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Analytics.NetStandard20", "Analytics.NetStandard20/Analytics.NetStandard20.csproj", "{57CCBFA9-8CE3-4260-8E83-951E281372FC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Analytics.NetStandard20", "Analytics.NetStandard20\Analytics.NetStandard20.csproj", "{57CCBFA9-8CE3-4260-8E83-951E281372FC}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.NetStandard20", "Test.NetStandard20/Test.NetStandard20.csproj", "{9D2DF2FC-3977-418C-8E0B-B98A48F596B7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.NetStandard20", "Test.NetStandard20\Test.NetStandard20.csproj", "{9D2DF2FC-3977-418C-8E0B-B98A48F596B7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Analytics.Net45", "Analytics.Net45\Analytics.Net45.csproj", "{3EBD38D6-E04D-4E23-88C1-2BC32689EE8B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -51,6 +53,10 @@ Global
 		{9D2DF2FC-3977-418C-8E0B-B98A48F596B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9D2DF2FC-3977-418C-8E0B-B98A48F596B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9D2DF2FC-3977-418C-8E0B-B98A48F596B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3EBD38D6-E04D-4E23-88C1-2BC32689EE8B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3EBD38D6-E04D-4E23-88C1-2BC32689EE8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3EBD38D6-E04D-4E23-88C1-2BC32689EE8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3EBD38D6-E04D-4E23-88C1-2BC32689EE8B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Analytics.Net35/Analytics.Net35.csproj
+++ b/Analytics.Net35/Analytics.Net35.csproj
@@ -15,13 +15,13 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DefineConstants>DEBUG;NET35;</DefineConstants>
+    <DefineConstants>DEBUG;</DefineConstants>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType></DebugType>
-    <DefineConstants>RELEASE;NET35;</DefineConstants>
+    <DefineConstants>RELEASE;</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Net" />

--- a/Analytics.Net45/Analytics.Net45.csproj
+++ b/Analytics.Net45/Analytics.Net45.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net451</TargetFrameworks>
+    <TargetFrameworks>net45</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>Analytics</PackageId>
     <Version>3.1.0-alpha</Version>

--- a/Analytics.Net45/Analytics.Net45.csproj
+++ b/Analytics.Net45/Analytics.Net45.csproj
@@ -1,0 +1,36 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net451</TargetFrameworks>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <PackageId>Analytics</PackageId>
+    <Version>3.1.0-alpha</Version>
+    <Authors>Segment Team</Authors>
+    <Company />
+    <Product>Analytics.NET</Product>
+    <Description>The .NET API for analytics, by Segment.</Description>
+    <DefineConstants>NET45</DefineConstants>
+    <RootNamespace>Analytics</RootNamespace>
+    <AssemblyName>Analytics</AssemblyName>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DefineConstants>DEBUG;</DefineConstants>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType></DebugType>
+    <DefineConstants>RELEASE;</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System.Net" />
+    <Compile Include="../Analytics/**/*.cs" Exclude="../Analytics/obj/**/*.cs">
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+  </ItemGroup>
+
+</Project>

--- a/Analytics.nuspec
+++ b/Analytics.nuspec
@@ -20,6 +20,10 @@
                 <dependency id="AsyncBridge.Net35" version="0.2.0" exclude="Build,Analyzers" />
                 <dependency id="Newtonsoft.Json" version="10.0.3" exclude="Build,Analyzers" />
             </group>
+            <group targetFramework="net45">
+                <dependency id="System.Net.Http" version="4.3.3" exclude="Build,Analyzers" />
+                <dependency id="Newtonsoft.Json" version="10.0.3" exclude="Build,Analyzers" />
+            </group>
             <group targetFramework=".NETStandard1.3, .NETStandard2.0">
                 <dependency id="System.Threading.Thread" version="4.3.0" exclude="Build,Analyzers" />
                 <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
@@ -32,6 +36,7 @@
     </metadata>
     <files>
         <file src="Analytics.Net35/bin/Release/net35/Analytics.dll" target="lib/net35/" />
+        <file src="Analytics.Net45/bin/Release/net45/Analytics.dll" target="lib/net45/" />
         <file src="Analytics.NetStandard20/bin/Release/netstandard2.0/Analytics.dll" target="lib/netstandard2.0/" />
         <file src="Analytics/bin/Release/netstandard1.3/Analytics.dll" target="lib/netstandard1.3/" />
     </files>

--- a/Analytics.nuspec
+++ b/Analytics.nuspec
@@ -24,7 +24,12 @@
                 <dependency id="System.Net.Http" version="4.3.3" exclude="Build,Analyzers" />
                 <dependency id="Newtonsoft.Json" version="10.0.3" exclude="Build,Analyzers" />
             </group>
-            <group targetFramework=".NETStandard1.3, .NETStandard2.0">
+            <group targetFramework="netstandard1.3">
+                <dependency id="System.Threading.Thread" version="4.3.0" exclude="Build,Analyzers" />
+                <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
+                <dependency id="Newtonsoft.Json" version="10.0.3" exclude="Build,Analyzers" />
+            </group>
+            <group targetFramework="netstandard2.0">
                 <dependency id="System.Threading.Thread" version="4.3.0" exclude="Build,Analyzers" />
                 <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
                 <dependency id="Newtonsoft.Json" version="10.0.3" exclude="Build,Analyzers" />

--- a/Analytics/Client.cs
+++ b/Analytics/Client.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Segment.Flush;
@@ -650,11 +650,17 @@ namespace Segment
             this.Statistics.Submitted = Statistics.Increment(this.Statistics.Submitted);
         }
 
-        #endregion
+		protected void ensureId(String userId, Options options)
+		{
+			if (String.IsNullOrEmpty(userId) && String.IsNullOrEmpty(options.AnonymousId))
+				throw new InvalidOperationException("Please supply a valid id (either userId or anonymousId.");
+		}
 
-        #region Event API
+		#endregion
 
-        internal void RaiseSuccess(BaseAction action)
+		#region Event API
+
+		internal void RaiseSuccess(BaseAction action)
         {
             if (Succeeded != null) Succeeded(action);
         }

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ assemble:
 	@msbuild Analytics/Analytics.csproj /p:Configuration=Release
 	@msbuild Analytics.Net35/Analytics.Net35.csproj /t:restore
 	@msbuild Analytics.Net35/Analytics.Net35.csproj /p:Configuration=Release
+	@msbuild Analytics.Net45/Analytics.Net45.csproj /t:restore
+	@msbuild Analytics.Net45/Analytics.Net45.csproj /p:Configuration=Release
 	@msbuild Analytics.NetStandard20/Analytics.NetStandard20.csproj /t:restore
 	@msbuild Analytics.NetStandard20/Analytics.NetStandard20.csproj /p:Configuration=Release
 

--- a/Test.Net45/ActionTests.cs
+++ b/Test.Net45/ActionTests.cs
@@ -1,0 +1,85 @@
+using System;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Segment.Test
+{
+	[TestFixture()]
+	public class ActionTests
+	{
+
+		[SetUp]
+		public void Init()
+		{
+			Analytics.Dispose();
+			Logger.Handlers += LoggingHandler;
+			Analytics.Initialize(Constants.WRITE_KEY, new Config().SetAsync(false));
+		}
+
+		[Test ()]
+		public void IdentifyTestNet45()
+		{
+			Actions.Identify(Analytics.Client);
+			FlushAndCheck(1);
+		}
+
+		[Test()]
+		public void TrackTestNet45()
+		{
+			Actions.Track(Analytics.Client);
+			FlushAndCheck(1);
+		}
+
+		[Test()]
+		public void AliasTestNet45()
+		{
+			Actions.Alias(Analytics.Client);
+			FlushAndCheck(1);
+		}
+
+		[Test()]
+		public void GroupTestNet45()
+		{
+			Actions.Group(Analytics.Client);
+			FlushAndCheck(1);
+		}
+
+		[Test()]
+		public void PageTestNet45()
+		{
+			Actions.Page(Analytics.Client);
+			FlushAndCheck(1);
+		}
+
+		[Test()]
+		public void ScreenTestNet45()
+		{
+			Actions.Screen(Analytics.Client);
+			FlushAndCheck(1);
+		}
+
+		private void FlushAndCheck(int messages)
+		{
+			Analytics.Client.Flush();
+			Assert.AreEqual(messages, Analytics.Client.Statistics.Submitted);
+			Assert.AreEqual(messages, Analytics.Client.Statistics.Succeeded);
+			Assert.AreEqual(0, Analytics.Client.Statistics.Failed);
+		}
+
+		static void LoggingHandler(Logger.Level level, string message, IDictionary<string, object> args)
+		{
+			if (args != null)
+			{
+				foreach (string key in args.Keys)
+				{
+					message += String.Format(" {0}: {1},", "" + key, "" + args[key]);
+				}
+			}
+			Console.WriteLine(String.Format("[ActionTests] [{0}] {1}", level, message));
+		}
+	}
+
+
+}
+

--- a/Test.Net45/Actions.cs
+++ b/Test.Net45/Actions.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Threading.Tasks;
+using Segment.Model;
+
+namespace Segment.Test
+{
+	public class Actions
+	{
+		private static Random random = new Random();
+
+		public static Properties Properties()
+		{
+			return new Properties() {
+				{ "Success", true },
+				{ "When", DateTime.Now }
+			};
+		}
+
+		public static Traits Traits()
+		{
+			return new Traits() {
+				{ "Subscription Plan", "Free" },
+				{ "Friends", 30 },
+				{ "Joined", DateTime.Now },
+				{ "Cool", true },
+				{ "Company", new Dict () { { "name", "Initech, Inc " } } },
+				{ "Revenue", 40.32 },
+				{ "Don't Submit This, Kids", new UnauthorizedAccessException () }
+			};
+		}
+
+		public static Options Options()
+		{
+			return new Options()
+				.SetTimestamp(DateTime.Now)
+				.SetAnonymousId(Guid.NewGuid().ToString())
+				.SetIntegration("all", false)
+				.SetIntegration("Mixpanel", true)
+				.SetIntegration("Salesforce", true)
+				.SetContext(new Context()
+					.Add("ip", "12.212.12.49")
+					.Add("language", "en-us")
+			);
+		}
+
+		public static void Identify(Client client)
+		{
+			client.Identify("user", Traits(), Options());
+			Analytics.Client.Flush();
+		}
+
+		public static void Group(Client client)
+		{
+			client.Group("user", "group", Traits(), Options());
+			Analytics.Client.Flush();
+		}
+
+		public static void Track(Client client)
+		{
+			client.Track("user", "Ran .NET test", Properties(), Options());
+		}
+
+		public static void Alias(Client client)
+		{
+			client.Alias("previousId", "to");
+		}
+
+		public static void Page(Client client)
+		{
+			client.Page("user", "name", "category", Properties(), Options());
+		}
+
+		public static void Screen(Client client)
+		{
+			client.Screen("user", "name", "category", Properties(), Options());
+		}
+
+		public static void Random(Client client)
+		{
+			switch (random.Next(0, 6))
+			{
+				case 0:
+					Identify(client);
+					return;
+				case 1:
+					Track(client);
+					return;
+				case 2:
+					Alias(client);
+					return;
+				case 3:
+					Group(client);
+					return;
+				case 4:
+					Page(client);
+					return;
+				case 5:
+					Screen(client);
+					return;
+			}
+		}
+	}
+}

--- a/Test.Net45/ClientTests.cs
+++ b/Test.Net45/ClientTests.cs
@@ -1,0 +1,30 @@
+using NUnit.Framework;
+
+using System;
+using System.Collections.Generic;
+
+using Segment;
+using Segment.Model;
+
+namespace Segment.Test
+{
+	[TestFixture ()]
+	public class ClientTests
+	{
+		Client client;
+
+		[SetUp]
+		public void Init()
+		{
+			client = new Client("foo");
+		}
+
+		[Test ()]
+		public void TrackTestNet45 ()
+		{
+			// verify it doesn't fail for a null options
+			client.Screen("bar", "qaz", null, null);
+		}
+	}
+}
+

--- a/Test.Net45/ClientTests.cs
+++ b/Test.Net45/ClientTests.cs
@@ -11,19 +11,58 @@ namespace Segment.Test
 	[TestFixture ()]
 	public class ClientTests
 	{
-		Client client;
-
-		[SetUp]
-		public void Init()
+		class TestClient : Client
 		{
-			client = new Client("foo");
+			public TestClient() : base("catpants")
+			{
+			}
+
+			public bool EnsureId(String userId, Options options)
+			{
+				try
+				{
+					base.ensureId(userId, options);
+				}
+				catch
+				{
+					return false;
+				}
+
+				return true;
+			}
 		}
 
-		[Test ()]
-		public void TrackTestNet45 ()
+		[Test]
+		public void HasUserId_NoOptions()
 		{
-			// verify it doesn't fail for a null options
-			client.Screen("bar", "qaz", null, null);
+			var test = new TestClient();
+			Assert.IsTrue(test.EnsureId("user id", null));
+		}
+
+		[Test]
+		public void NoUserId_HasAnonId()
+		{
+			var test = new TestClient();
+
+			var options = new Options();
+			options.SetAnonymousId("anon id");
+			Assert.IsTrue(test.EnsureId("", options));
+		}
+
+		[Test]
+		public void NoUserId_NoAnon()
+		{
+			var test = new TestClient();
+
+			Assert.IsFalse(test.EnsureId("", new Options()));
+		}
+
+		[Test]
+		public void NoUserId_NoOptions()
+		{
+			var test = new TestClient();
+
+			Assert.IsFalse(test.EnsureId("", null));
 		}
 	}
 }

--- a/Test.Net45/ConnectionTests.cs
+++ b/Test.Net45/ConnectionTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+
+namespace Segment.Test
+{
+	[TestFixture()]
+	public class ConnectionTests
+    {
+		[SetUp]
+		public void Init()
+		{
+			Analytics.Dispose();
+			Logger.Handlers += LoggingHandler;
+		}
+
+		[Test()]
+		public void ProxyTestNet45()
+		{
+			// Set proxy address, like as "http://localhost:8888"
+			Analytics.Initialize(Constants.WRITE_KEY, new Config().SetAsync(false).SetProxy(""));
+
+			Actions.Identify(Analytics.Client);
+
+			Assert.AreEqual(1, Analytics.Client.Statistics.Submitted);
+			Assert.AreEqual(1, Analytics.Client.Statistics.Succeeded);
+			Assert.AreEqual(0, Analytics.Client.Statistics.Failed);
+		}
+
+		static void LoggingHandler(Logger.Level level, string message, IDictionary<string, object> args)
+		{
+			if (args != null)
+			{
+				foreach (string key in args.Keys)
+				{
+					message += String.Format(" {0}: {1},", "" + key, "" + args[key]);
+				}
+			}
+			Console.WriteLine(String.Format("[ConnectionTests] [{0}] {1}", level, message));
+		}
+	}
+}

--- a/Test.Net45/Constants.cs
+++ b/Test.Net45/Constants.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Segment.Test
+{
+	public class Constants
+	{
+		// project segmentio/dotnet-test
+		public static string WRITE_KEY = "r7bxis28wy";
+	}
+}
+

--- a/Test.Net45/FlushTests.cs
+++ b/Test.Net45/FlushTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Segment.Model;
+
+namespace Segment.Test
+{
+	[TestFixture()]
+	public class FlushTests
+	{
+		[SetUp]
+		public void Init()
+		{
+			Analytics.Dispose();
+			Logger.Handlers += LoggingHandler;
+		}
+
+		[Test()]
+		public void SynchronousFlushTestNet45()
+		{
+			Analytics.Initialize(Constants.WRITE_KEY, new Config().SetAsync(false));
+			Analytics.Client.Succeeded += Client_Succeeded;
+			Analytics.Client.Failed += Client_Failed;
+
+			int trials = 10;
+
+			RunTests(Analytics.Client, trials);
+
+			Assert.AreEqual(trials, Analytics.Client.Statistics.Submitted);
+			Assert.AreEqual(trials, Analytics.Client.Statistics.Succeeded);
+			Assert.AreEqual(0, Analytics.Client.Statistics.Failed);
+		}
+
+		[Test()]
+		public void AsynchronousFlushTestNet45()
+		{
+			Analytics.Initialize(Constants.WRITE_KEY, new Config().SetAsync(true));
+
+			Analytics.Client.Succeeded += Client_Succeeded;
+			Analytics.Client.Failed += Client_Failed;
+
+			int trials = 10;
+
+			RunTests(Analytics.Client, trials);
+
+			Thread.Sleep(1000); // cant use flush to wait during asynchronous flushing
+
+			Assert.AreEqual(trials, Analytics.Client.Statistics.Submitted);
+			Assert.AreEqual(trials, Analytics.Client.Statistics.Succeeded);
+			Assert.AreEqual(0, Analytics.Client.Statistics.Failed);
+		}
+
+		[Test()]
+		public void PerformanceTestNet45()
+		{
+			Analytics.Initialize(Constants.WRITE_KEY);
+
+			Analytics.Client.Succeeded += Client_Succeeded;
+			Analytics.Client.Failed += Client_Failed;
+
+			int trials = 100;
+
+			DateTime start = DateTime.Now;
+
+			RunTests(Analytics.Client, trials);
+
+			Analytics.Client.Flush();
+
+			TimeSpan duration = DateTime.Now.Subtract(start);
+
+			Assert.AreEqual(trials, Analytics.Client.Statistics.Submitted);
+			Assert.AreEqual(trials, Analytics.Client.Statistics.Succeeded);
+			Assert.AreEqual(0, Analytics.Client.Statistics.Failed);
+
+			Assert.IsTrue(duration.CompareTo(TimeSpan.FromSeconds(20)) < 0);
+		}
+
+		private void RunTests(Client client, int trials)
+		{
+			for (int i = 0; i < trials; i += 1)
+			{
+				Actions.Random(client);
+			}
+		}
+
+		void Client_Failed(BaseAction action, System.Exception e)
+		{
+			Console.WriteLine(String.Format("Action [{0}] {1} failed : {2}",
+				action.MessageId, action.Type, e.Message));
+		}
+
+		void Client_Succeeded(BaseAction action)
+		{
+			Console.WriteLine(String.Format("Action [{0}] {1} succeeded.",
+				action.MessageId, action.Type));
+		}
+
+		static void LoggingHandler(Logger.Level level, string message, IDictionary<string, object> args)
+		{
+			if (args != null)
+			{
+				foreach (string key in args.Keys)
+				{
+					message += String.Format(" {0}: {1},", "" + key, "" + args[key]);
+				}
+			}
+			Console.WriteLine(String.Format("[FlushTests] [{0}] {1}", level, message));
+		}
+	}
+}
+

--- a/Test.Net45/Program.cs
+++ b/Test.Net45/Program.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Segment;
+using Segment.Test;
+
+namespace Segment.Test
+{
+	class Program
+	{
+		static void Main(string[] args)
+		{
+			Logger.Handlers += Logger_Handlers;
+
+			//Analytics.Initialize(Segment.Test.Constants.WRITE_KEY);
+
+			//FlushTests tests = new FlushTests();
+			//tests.PerformanceTestNet45();
+			Analytics.Initialize("nAZ4rSBdQMoMJ6bswze53Jorbpjtne78");
+			Analytics.Client.Track("prateek", "Item Purchased");
+			Analytics.Client.Flush();
+		}
+
+		private static void Logger_Handlers(Logger.Level level, string message, IDictionary<string, object> args)
+		{
+			Console.WriteLine(message);
+		}
+	}
+}

--- a/Test.Net45/Properties/AssemblyInfo.cs
+++ b/Test.Net45/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Test.Net45")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Test.Net45")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("31700b78-412a-4294-a095-571f7a325799")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Test.Net45/Test.Net45.csproj
+++ b/Test.Net45/Test.Net45.csproj
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)/$(MSBuildToolsVersion)/Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)/$(MSBuildToolsVersion)/Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A7B43E75-BA62-4543-A467-27C6D9B28EB8}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <StartupObject />
+    <OutputPath>bin/$(Configuration)/</OutputPath>
+    <RootNamespace>Segment.Test</RootNamespace>
+    <AssemblyName>Test.Net45</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin/Debug/</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin/Release/</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net" />
+    <Reference Include="System.Threading, Version=1.0.2856.102, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>../packages/TaskParallelLibrary.1.0.2856.0/lib/Net35/System.Threading.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Actions.cs" />
+    <Compile Include="ActionTests.cs" />
+    <Compile Include="ClientTests.cs" />
+    <Compile Include="ConnectionTests.cs" />
+    <Compile Include="Constants.cs" />
+    <Compile Include="FlushTests.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties/AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Analytics.Net45/Analytics.Net45.csproj">
+      <Project>{3EBD38D6-E04D-4E23-88C1-2BC32689EE8B}</Project>
+      <Name>Analytics.Net45</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)/Microsoft.CSharp.targets" />
+</Project>

--- a/Test.Net45/Test.Net45.csproj
+++ b/Test.Net45/Test.Net45.csproj
@@ -10,7 +10,7 @@
     <OutputPath>bin/$(Configuration)/</OutputPath>
     <RootNamespace>Segment.Test</RootNamespace>
     <AssemblyName>Test.Net45</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Test.Net45/packages.config
+++ b/Test.Net45/packages.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.9.0" targetFramework="net451" />
+  <package id="NUnit.ConsoleRunner" version="3.7.0" targetFramework="net35" />
+  <package id="NUnit.Extension.NUnitProjectLoader" version="3.5.0" targetFramework="net35" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.6.0" targetFramework="net35" />
+  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.5.0" targetFramework="net35" />
+  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net35" />
+  <package id="NUnit.Extension.VSProjectLoader" version="3.5.0" targetFramework="net35" />
+  <package id="NUnit.Runners" version="3.7.0" targetFramework="net35" />
+  <package id="TaskParallelLibrary" version="1.0.2856.0" targetFramework="net35" />
+</packages>

--- a/Test.Net45/packages.config
+++ b/Test.Net45/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.9.0" targetFramework="net451" />
-  <package id="NUnit.ConsoleRunner" version="3.7.0" targetFramework="net35" />
-  <package id="NUnit.Extension.NUnitProjectLoader" version="3.5.0" targetFramework="net35" />
-  <package id="NUnit.Extension.NUnitV2Driver" version="3.6.0" targetFramework="net35" />
-  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.5.0" targetFramework="net35" />
-  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net35" />
-  <package id="NUnit.Extension.VSProjectLoader" version="3.5.0" targetFramework="net35" />
-  <package id="NUnit.Runners" version="3.7.0" targetFramework="net35" />
-  <package id="TaskParallelLibrary" version="1.0.2856.0" targetFramework="net35" />
+  <package id="NUnit" version="3.8.1" targetFramework="net45" />
+  <package id="NUnit.ConsoleRunner" version="3.7.0" targetFramework="net45" />
+  <package id="NUnit.Extension.NUnitProjectLoader" version="3.5.0" targetFramework="net45" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.6.0" targetFramework="net45" />
+  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.5.0" targetFramework="net45" />
+  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net45" />
+  <package id="NUnit.Extension.VSProjectLoader" version="3.5.0" targetFramework="net45" />
+  <package id="NUnit.Runners" version="3.7.0" targetFramework="net45" />
+  <package id="TaskParallelLibrary" version="1.0.2856.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Analytics.Xamarin library is based on .Net framework 4.5.1.
We can use Analytics.Net library with .Net 4.5.1 instead of Analytics.Xamarin.Pcl.