### PR TITLE
Fix portable build error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,13 +7,14 @@ jobs:
     environment:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_CLI_TELEMETRY_OUTPUT: 1
+    dependencies:
+      pre:
+        # Update mono to latest version (5.8)
+        - echo "deb http://download.mono-project.com/repo/ubuntu trusty main" | tee /etc/apt/sources.list.d/mono-official.list
+        - apt-get update
+        - apt-get install -y mono-devel
+        - mono -V   # Check mono version
     steps:
-      # Update mono to latest version (5.8)
-      - echo "deb http://download.mono-project.com/repo/ubuntu trusty main" | tee /etc/apt/sources.list.d/mono-official.list
-      - apt-get update
-      - apt-get install -y mono-devel
-      - mono -V   # Check mono version
-      # Download project and try to build
       - checkout
       - run: msbuild Analytics/Analytics.csproj /t:restore
       - run: msbuild Analytics/Analytics.csproj /p:Configuration=Release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,12 @@ jobs:
     environment:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_CLI_TELEMETRY_OUTPUT: 1
-        # Update mono to latest version (5.8)
     steps:
+      # Update mono to latest version (5.8)
       - run: echo "deb http://download.mono-project.com/repo/ubuntu trusty main" | tee /etc/apt/sources.list.d/mono-official.list
       - run: apt-get update
       - run: apt-get install -y mono-devel
-      - run: mono -V   # Check mono version
+      # Checkout source code and try to build & pack
       - checkout
       - run: msbuild Analytics/Analytics.csproj /t:restore
       - run: msbuild Analytics/Analytics.csproj /p:Configuration=Release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,17 @@ jobs:
   build:
     working_directory: /temp
     docker:
-      - image: mono:5.8.0.108
+      - image: mono:latest
     environment:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_CLI_TELEMETRY_OUTPUT: 1
     steps:
+      # Update mono to latest version (5.8)
+      - echo "deb http://download.mono-project.com/repo/ubuntu trusty main" | tee /etc/apt/sources.list.d/mono-official.list
+      - apt-get update
+      - apt-get install -y mono-devel
+      - mono -V   # Check mono version
+      # Download project and try to build
       - checkout
       - run: msbuild Analytics/Analytics.csproj /t:restore
       - run: msbuild Analytics/Analytics.csproj /p:Configuration=Release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,12 @@ jobs:
     environment:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_CLI_TELEMETRY_OUTPUT: 1
-    dependencies:
-      pre:
         # Update mono to latest version (5.8)
-        - echo "deb http://download.mono-project.com/repo/ubuntu trusty main" | tee /etc/apt/sources.list.d/mono-official.list
-        - apt-get update
-        - apt-get install -y mono-devel
-        - mono -V   # Check mono version
     steps:
+      - run: echo "deb http://download.mono-project.com/repo/ubuntu trusty main" | tee /etc/apt/sources.list.d/mono-official.list
+      - run: apt-get update
+      - run: apt-get install -y mono-devel
+      - run: mono -V   # Check mono version
       - checkout
       - run: msbuild Analytics/Analytics.csproj /t:restore
       - run: msbuild Analytics/Analytics.csproj /p:Configuration=Release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2
 jobs:
   build:
     working_directory: /temp
-    docker:  
-      - image: mono:latest
+    docker:
+      - image: mono:5.8.0.108-slim
     environment:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_CLI_TELEMETRY_OUTPUT: 1
@@ -22,7 +22,7 @@ jobs:
       - run: nuget pack Analytics.nuspec
   test:
     working_directory: /test
-    docker:  
+    docker:
       - image: microsoft/dotnet:1.1.1-sdk
     environment:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -33,7 +33,7 @@ jobs:
       - run: dotnet test Test/Test.csproj
   test_35:
     working_directory: /test35
-    docker:  
+    docker:
       - image: mono:latest
     environment:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -46,7 +46,7 @@ jobs:
       - run: mono --debug ./packages/NUnit.ConsoleRunner.3.7.0/tools/nunit3-console.exe Test.Net35/bin/Release/Test.Net35.dll
   test_45:
     working_directory: /test45
-    docker:  
+    docker:
       - image: mono:latest
     environment:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -59,7 +59,7 @@ jobs:
       - run: mono --debug ./packages/NUnit.ConsoleRunner.3.7.0/tools/nunit3-console.exe Test.Net45/bin/Release/Test.Net45.dll
   test_e2e:
     working_directory: /test_e2e
-    docker:  
+    docker:
       - image: microsoft/dotnet:1.1.1-sdk
     environment:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /temp
     docker:
-      - image: mono:5.8.0.108-slim
+      - image: mono:5.8.0.108
     environment:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_CLI_TELEMETRY_OUTPUT: 1


### PR DESCRIPTION
Current docker image uses mono version 5.4.
It occurs error while building portable version of Analytics.Net library.  (It doesn't install nuget package which is defined in project file)
So I install latest version of mono before building project.