### PR TITLE
Add destination specific options

### DIFF
--- a/Analytics/Model/Options.cs
+++ b/Analytics/Model/Options.cs
@@ -73,5 +73,25 @@ namespace Segment.Model
 			return this;
 		}
 
+		/// <summary>
+		/// Enable destination specific options for integration.
+		/// For example, to send tags in https://segment.com/docs/destinations/vero/#tags, use following
+		///   new Options()
+		///     .Integration("Vero", new Model.Dict() {
+		///			"tags", new Model.Dict() {
+		///             { "id", "235FAG" },
+		///             { "action", "add" },
+		///             { "values", new string[] {"warriors", "giants", "niners"} }
+		///         }
+		///     });
+		/// </summary>
+		/// <param name="integration">The integration name.</param>
+		/// <param name="value">Dict value</param>
+		public Options SetIntegration (string integration, Dict value)
+		{
+			this.Integrations.Add (integration, value);
+			return this;
+		}
+
 	}
 }

--- a/Test.Net35/ActionTests.cs
+++ b/Test.Net35/ActionTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -21,6 +21,27 @@ namespace Segment.Test
 		public void IdentifyTestNet35()
 		{
 			Actions.Identify(Analytics.Client);
+			FlushAndCheck(1);
+		}
+
+		[Test()]
+		public void IdentifyWithCustomOptionsTestNet35()
+		{
+			var traits = new Model.Traits() {
+				{ "email", "friends@segment.com" }
+			};
+			var options = new Model.Options()
+				.SetIntegration("Vero", new Model.Dict() {
+					{
+						"tags", new Model.Dict() {
+							{ "id", "235FAG" },
+							{ "action", "add" },
+							{ "values", new string[] {"warriors", "giants", "niners"} }
+						}
+					}
+				});
+
+			Actions.Identify(Analytics.Client, traits, options);
 			FlushAndCheck(1);
 		}
 

--- a/Test.Net35/Actions.cs
+++ b/Test.Net35/Actions.cs
@@ -49,6 +49,12 @@ namespace Segment.Test
 			Analytics.Client.Flush();
 		}
 
+		public static void Identify(Client client, Traits traits, Options options)
+		{
+			client.Identify("user", traits, options);
+			Analytics.Client.Flush();
+		}
+
 		public static void Group(Client client)
 		{
 			client.Group("user", "group", Traits(), Options());

--- a/Test.Net45/ActionTests.cs
+++ b/Test.Net45/ActionTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -21,6 +21,27 @@ namespace Segment.Test
 		public void IdentifyTestNet45()
 		{
 			Actions.Identify(Analytics.Client);
+			FlushAndCheck(1);
+		}
+
+		[Test()]
+		public void IdentifyWithCustomOptionsTestNet45()
+		{
+			var traits = new Model.Traits() {
+				{ "email", "friends@segment.com" }
+			};
+			var options = new Model.Options()
+				.SetIntegration("Vero", new Model.Dict() {
+					{
+						"tags", new Model.Dict() {
+							{ "id", "235FAG" },
+							{ "action", "add" },
+							{ "values", new string[] {"warriors", "giants", "niners"} }
+						}
+					}
+				});
+
+			Actions.Identify(Analytics.Client, traits, options);
 			FlushAndCheck(1);
 		}
 

--- a/Test.Net45/Actions.cs
+++ b/Test.Net45/Actions.cs
@@ -49,6 +49,12 @@ namespace Segment.Test
 			Analytics.Client.Flush();
 		}
 
+		public static void Identify(Client client, Traits traits, Options options)
+		{
+			client.Identify("user", traits, options);
+			Analytics.Client.Flush();
+		}
+
 		public static void Group(Client client)
 		{
 			client.Group("user", "group", Traits(), Options());

--- a/Test/ActionTests.cs
+++ b/Test/ActionTests.cs
@@ -25,6 +25,27 @@ namespace Segment.Test
 		}
 
 		[Test()]
+		public void IdentifyWithCustomOptionsTest()
+		{
+			var traits = new Model.Traits() {
+				{ "email", "friends@segment.com" }
+			};
+			var options = new Model.Options()
+				.SetIntegration("Vero", new Model.Dict() {
+					{
+						"tags", new Model.Dict() {
+							{ "id", "235FAG" },
+							{ "action", "add" },
+							{ "values", new string[] {"warriors", "giants", "niners"} }
+						}
+					}
+				});
+
+			Actions.Identify(Analytics.Client, traits, options);
+			FlushAndCheck(1);
+		}
+
+		[Test()]
 		public void TrackTest()
 		{
 			Actions.Track(Analytics.Client);

--- a/Test/Actions.cs
+++ b/Test/Actions.cs
@@ -49,6 +49,12 @@ namespace Segment.Test
 			Analytics.Client.Flush();
 		}
 
+		public static void Identify(Client client, Traits traits, Options options)
+		{
+			client.Identify("user", traits, options);
+			Analytics.Client.Flush();
+		}
+
 		public static void Group(Client client)
 		{
 			client.Group("user", "group", Traits(), Options());


### PR DESCRIPTION
Now we can use JSON object (presented by Segment.Model.Dict) for integration.
Sample code is attached for https://segment.com/docs/destinations/vero/#tags