### PR TITLE
Add Analytics.Portable project into makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ assemble:
 	@msbuild Analytics.Net45/Analytics.Net45.csproj /p:Configuration=Release
 	@msbuild Analytics.NetStandard20/Analytics.NetStandard20.csproj /t:restore
 	@msbuild Analytics.NetStandard20/Analytics.NetStandard20.csproj /p:Configuration=Release
+	@msbuild Analytics.Portable/Analytics.Portable.csproj /t:restore
+	@msbuild Analytics.Portable/Analytics.Portable.csproj /p:Configuration=Release
 
 test: assemble
 	@nunit-console Test/bin/Debug/Test.dll


### PR DESCRIPTION
Analytics.Portable project was missing in makefile
So an error can be occurred while executing "nuget pack" after run makefile