### PR TITLE
Fix for User-Agent header duplication on each http request

### DIFF
--- a/Analytics/Request/BlockingRequestHandler.cs
+++ b/Analytics/Request/BlockingRequestHandler.cs
@@ -164,19 +164,12 @@ namespace Segment.Request
 					}
 				}
 
-				var requestInfo = new Dict
+				Logger.Info("Sending analytics request to Segment.io ..", new Dict
 				{
 					{ "batch id", batch.MessageId },
 					{ "json size", json.Length },
 					{ "batch size", batch.batch.Count }
-				};
-
-				if (_client.Config.CompressRequest)
-				{
-					requestInfo.Add("gzipped json size", requestData.Length);
-				}
-
-				Logger.Info("Sending analytics request to Segment.io ..", requestInfo);
+				});
 
 				// Retries with exponential backoff
 				const int MAXIMUM_BACKOFF_DURATION = 10000;	// Set maximum waiting limit to 10s

--- a/Analytics/Request/BlockingRequestHandler.cs
+++ b/Analytics/Request/BlockingRequestHandler.cs
@@ -242,7 +242,7 @@ namespace Segment.Request
 							// If status code is greater than 500 and less than 600, it indicates server error
 							// Error code 429 indicates rate limited.
 							// Retry uploading in these cases.
-							await Task.Delay(backoff).ConfigureAwait(false);
+							Task.Delay(backoff).Wait();
 							backoff *= 2;
 							continue;
 						}
@@ -256,7 +256,7 @@ namespace Segment.Request
 #endif
 				}
 
-				if (backoff >= MAXIMUM_BACKOFF_DURATION || statusCode != (int)HttpStatusCode.OK)
+				if (backoff == MAXIMUM_BACKOFF_DURATION && statusCode != (int)HttpStatusCode.OK)
 				{
 					Fail(batch, new APIException("Unexpected Status Code", responseStr), watch.ElapsedMilliseconds);
 				}

--- a/Test.Net45/Test.Net45.csproj
+++ b/Test.Net45/Test.Net45.csproj
@@ -36,8 +36,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Currently "User-Agent" header is added on each `MakeRequest` call and it's value gets duplicated ([docs](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.headers.httpheaders.add?view=netcore-2.0#System_Net_Http_Headers_HttpHeaders_Add_System_String_System_String_)). If client application uses `Analytics.Client` as a singleton then after some time "User-Agent" header reaches request limits on Segment and it will always return `400 Bad Request`. This PR moves header initilialization to `BlockingRequestHandler`constructor and also fixes handling of errors.