### PR TITLE
Bump System.Text.RegularExpressions from 4.3.0 to 4.3.1 in Analytics

### DIFF
--- a/Analytics/Analytics.csproj
+++ b/Analytics/Analytics.csproj
@@ -31,6 +31,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net35'">


### PR DESCRIPTION
Fixing security vulnerability within dependency identified [here](https://app.snyk.io/org/segment-pro/project/10c13f0d-60df-4720-beb8-df0967d09f9b?action=retest&success=true&result=RETESTED).

Bumping System.Text.RegularExpressions from 4.3.0 to 4.3.1 for target framework netstandard1.3.