### PR TITLE
Bumped version of Newtonsoft.Json and System.Text.RegularExpressions

### DIFF
--- a/Test.E2E/Test.E2E.csproj
+++ b/Test.E2E/Test.E2E.csproj
@@ -10,9 +10,10 @@
   <ItemGroup>
     <PackageReference Include="Analytics" Version="3.2.0-alpha" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
This is to resolve security vulnerability in a dependency as outlined in [this report](https://app.snyk.io/org/segment-pro/project/5c44424a-2b3f-4957-bd4f-0c8d765c8bb3).

Bumping `System.Text.RegularExpressions` from 4.3.0 to 4.3.1.

Also bumping `Newtonsoft.Json` from 10.0.3 to 12.0.3.