### PR TITLE
Bump System.Text.RegularExpressions from 4.3.0 to 4.3.1

### DIFF
--- a/DI/Analytics.Extensions.Microsoft.DependencyInjection.Test/Analytics.Extensions.Microsoft.DependencyInjection.Test.csproj
+++ b/DI/Analytics.Extensions.Microsoft.DependencyInjection.Test/Analytics.Extensions.Microsoft.DependencyInjection.Test.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
To remediate security vulnerability in dependency identified [here](https://app.snyk.io/org/segment-pro/project/ae5bed39-08c7-4d20-8920-08a47e972c05), bumping version of System.Text.RegularExpressions.