### PR TITLE
Di dependecy injection integration to main nuget

### DIFF
--- a/Analytics/Analytics.cs
+++ b/Analytics/Analytics.cs
@@ -3,7 +3,7 @@ namespace Segment
     public class Analytics
     {
         // REMINDER: don't forget to set Properties.AssemblyInfo.AssemblyVersion as well
-        public static string VERSION = "3.4.2-beta";
+        public static string VERSION = "3.5.0";
 
         /// <summary>
         /// Lock for thread-safety

--- a/Analytics/Analytics.csproj
+++ b/Analytics/Analytics.csproj
@@ -82,4 +82,18 @@
     </None>
   </ItemGroup>
 
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions">
+      <Version>2.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions">
+      <Version>2.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/Analytics/Analytics.csproj
+++ b/Analytics/Analytics.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Segment</RootNamespace>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>Analytics</PackageId>
-    <Version>3.4.2-beta</Version>
+    <Version>3.5.0</Version>
     <Authors>Segment Team</Authors>
     <Company />
     <Product>Analytics.NET</Product>

--- a/Analytics/Extensions/ServiceCollectionExtension.cs
+++ b/Analytics/Extensions/ServiceCollectionExtension.cs
@@ -1,4 +1,4 @@
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET461
 using Microsoft.Extensions.DependencyInjection;
 #endif
 
@@ -6,7 +6,7 @@ namespace Segment.Extensions
 {
     public static class ServiceCollectionExtension
     {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET461
         public static void AddAnalytics(this IServiceCollection services, string writeKey, Config config = null)
         {
             Config configuration;

--- a/Analytics/Extensions/ServiceCollectionExtension.cs
+++ b/Analytics/Extensions/ServiceCollectionExtension.cs
@@ -1,16 +1,24 @@
+#if NETSTANDARD2_0
 using Microsoft.Extensions.DependencyInjection;
-using System;
-using System.Collections.Generic;
-using System.Text;
+#endif
 
 namespace Segment.Extensions
 {
     public static class ServiceCollectionExtension
     {
+#if NETSTANDARD2_0
         public static void AddAnalytics(this IServiceCollection services, string writeKey, Config config = null)
         {
-            var client = new Client(writeKey, config);
+            Config configuration;
+
+            if(config == null)
+                configuration = new Config();
+            else
+                configuration = config;
+
+            var client = new Client(writeKey, configuration);
             services.AddSingleton<IAnalyticsClient>(client);
         }
+#endif
     }
 }

--- a/Analytics/Extensions/ServiceCollectionExtension.cs
+++ b/Analytics/Extensions/ServiceCollectionExtension.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Segment.Extensions
+{
+    public static class ServiceCollectionExtension
+    {
+        public static void AddAnalytics(this IServiceCollection services, string writeKey, Config config = null)
+        {
+            var client = new Client(writeKey, config);
+            services.AddSingleton<IAnalyticsClient>(client);
+        }
+    }
+}

--- a/Test.NetStandard20/Extensions/ServiceCollectionExtensionTests.cs
+++ b/Test.NetStandard20/Extensions/ServiceCollectionExtensionTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Segment.Extensions;
+
+
+namespace Segment.Test.Extensions
+{
+    [TestFixture]
+    public class ServiceCollectionExtensionTests
+    {
+
+        [Test]
+        public void TestInicializationOfClientWithServicesCollection()
+        {
+            var writeKey = "writeKey";
+            var services = new ServiceCollection();
+            services.AddAnalytics(writeKey);
+
+            var provider = services.BuildServiceProvider();
+            var analyticsInstance = provider.GetRequiredService(typeof(IAnalyticsClient));
+
+            Assert.IsNotNull(analyticsInstance);
+
+            var client = analyticsInstance as Client;
+            Assert.AreEqual("writeKey", client.WriteKey);
+        }
+
+        [Test]
+        public void TestInicializationOfClientWithServicesCollectionAndConfig()
+        {
+            var writeKey = "writeKey";
+            var threadCount = 10;
+            var config = new Config { Threads = threadCount };
+
+            var services = new ServiceCollection();
+            services.AddAnalytics(writeKey, config);
+
+            var provider = services.BuildServiceProvider();
+            var analyticsInstance = provider.GetRequiredService(typeof(IAnalyticsClient));
+
+            Assert.IsNotNull(analyticsInstance);
+
+            var client = analyticsInstance as Client;
+            Assert.AreEqual("writeKey", client.WriteKey);
+            Assert.AreEqual(threadCount, client.Config.Threads);
+        }
+    }
+}

--- a/Test.NetStandard20/Test.NetStandard20.csproj
+++ b/Test.NetStandard20/Test.NetStandard20.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.8.1" />

--- a/Test/Extensions/ServiceCollectionExtensionTests.cs
+++ b/Test/Extensions/ServiceCollectionExtensionTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Segment.Extensions;
+
+
+namespace Segment.Test.Extensions
+{
+    [TestFixture]
+    public class ServiceCollectionExtensionTests
+    {
+
+        [Test]
+        public void TestInicializationOfClientWithServicesCollection()
+        {
+            var writeKey = "writeKey";
+            var services = new ServiceCollection();
+            services.AddAnalytics(writeKey);
+
+            var provider = services.BuildServiceProvider();
+            var analyticsInstance = provider.GetRequiredService(typeof(IAnalyticsClient));
+
+            Assert.IsNotNull(analyticsInstance);
+
+            var client = analyticsInstance as Client;
+            Assert.AreEqual("writeKey", client.WriteKey);
+        }
+
+        [Test]
+        public void TestInicializationOfClientWithServicesCollectionAndConfig()
+        {
+            var writeKey = "writeKey";
+            var threadCount = 10;
+            var config = new Config { Threads = threadCount };
+
+            var services = new ServiceCollection();
+            services.AddAnalytics(writeKey, config);
+
+            var provider = services.BuildServiceProvider();
+            var analyticsInstance = provider.GetRequiredService(typeof(IAnalyticsClient));
+
+            Assert.IsNotNull(analyticsInstance);
+
+            var client = analyticsInstance as Client;
+            Assert.AreEqual("writeKey", client.WriteKey);
+            Assert.AreEqual(threadCount, client.Config.Threads);
+        }
+    }
+}

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.8.1" />


### PR DESCRIPTION

The objective of this pull request is to integrate the DI project into the main nuget, to avoid the release of an external nuget to provide this functionality. 
This will allow the users whose project runs in .NET Standard 2.0, .NET Core and .NET Framework 4.6.1 to initialize the Analytics client on their startup and make use of it through dependency injection. 
The following link contains a video displaying this functionality: https://drive.google.com/file/d/1p4wUU3TAmxxQwRdMgra4noKptCMtCmjL/view?usp=sharing