### PR TITLE
Issue#167 events not sent to segment servers failed to send analytic event

### DIFF
--- a/Analytics/Request/BlockingRequestHandler.cs
+++ b/Analytics/Request/BlockingRequestHandler.cs
@@ -152,7 +152,7 @@ namespace Segment.Request
         public async Task MakeRequest(Batch batch)
         {
             Stopwatch watch = new Stopwatch();
-
+            _backo.Reset();
             try
             {
                 Uri uri = new Uri(_client.Config.Host + "/v1/import");
@@ -346,10 +346,6 @@ namespace Segment.Request
                 {
                     var message = $"Has Backoff reached max: {hasBackoReachedMax} with number of Attempts:{_backo.CurrentAttempt},\n Status Code: {statusCode}\n, response message: {responseStr}";
                     Fail(batch, new APIException(statusCode.ToString(), message), watch.ElapsedMilliseconds);
-                    if (_backo.HasReachedMax)
-                    {
-                        _backo.Reset();
-                    }
                 }
             }
             catch (System.Exception e)


### PR DESCRIPTION
Changed place where backo is reset so as to when new batch of Actions is going to be send to server, the attempt time of _backo is reset